### PR TITLE
Add Jasper library

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Deprecated datasets will remain available, but their benchmark results will not 
 | [IVF (Faiss)](https://github.com/facebookresearch/faiss) | 1.14.3 |
 | [IVF-PQ (Faiss)](https://github.com/facebookresearch/faiss) | 1.14.3 |
 | [IVF-RaBitQ](https://github.com/VectorDB-NTU/RaBitQ-Library) | git+5ea4df0 |
-| [Jasper](https://github.com/saltsystemslab/Jasper) | git+3355045 |
+| [Jasper](https://github.com/saltsystemslab/Jasper) | git+23647b9 |
 | [LVQ (SVS)](https://github.com/intel/ScalableVectorSearch) | 0.4.0 |
 | [LeanVec (SVS)](https://github.com/intel/ScalableVectorSearch) | 0.4.0 |
 | [LoRANN](https://github.com/ejaasaari/lorann) | 0.4.5 |

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Deprecated datasets will remain available, but their benchmark results will not 
 | [IVF (Faiss)](https://github.com/facebookresearch/faiss) | 1.14.3 |
 | [IVF-PQ (Faiss)](https://github.com/facebookresearch/faiss) | 1.14.3 |
 | [IVF-RaBitQ](https://github.com/VectorDB-NTU/RaBitQ-Library) | git+5ea4df0 |
+| [Jasper](https://github.com/saltsystemslab/Jasper) | git+3355045 |
 | [LVQ (SVS)](https://github.com/intel/ScalableVectorSearch) | 0.4.0 |
 | [LeanVec (SVS)](https://github.com/intel/ScalableVectorSearch) | 0.4.0 |
 | [LoRANN](https://github.com/ejaasaari/lorann) | 0.4.5 |

--- a/vibe/algorithms/jasper/config.yml
+++ b/vibe/algorithms/jasper/config.yml
@@ -1,0 +1,157 @@
+float:
+  euclidean:
+  - base_args: ['@metric']
+    constructor: Jasper
+    disabled: false
+    gpu: true
+    singularity_image: jasper
+    module: vibe.algorithms.jasper
+    name: jasper-base
+    run_groups:
+      jasper-8:
+        args:
+          n_neighbors: [8]
+          alpha: [1.2]
+        query_args:
+          beam_width: [16, 32, 64, 128, 256, 512, 1024, 1536]
+      jasper-16:
+        args:
+          n_neighbors: [16]
+          alpha: [1.2]
+        query_args:
+          beam_width: [16, 32, 64, 128, 256, 512, 1024, 1536]
+      jasper-32:
+        args:
+          n_neighbors: [32]
+          alpha: [1.2]
+        query_args:
+          beam_width: [16, 32, 64, 128, 256, 512, 1024, 1536]
+      jasper-64:
+        args:
+          n_neighbors: [64]
+          alpha: [1.2]
+        query_args:
+          beam_width: [32, 64, 128, 256, 512, 1024, 1536]
+  - base_args: ['@metric', 'cph']
+    constructor: JasperDirectional
+    disabled: false
+    gpu: true
+    singularity_image: jasper
+    module: vibe.algorithms.jasper
+    name: jasper-directional-cph
+    run_groups:
+      jasper-cph-32:
+        args:
+          n_neighbors: [32]
+          alpha: [1.2]
+          k_ranks: [4, 16]
+        query_args:
+          beam_width: [16, 32, 64, 128, 256, 512, 1024, 1536]
+      jasper-cph-64:
+        args:
+          n_neighbors: [64]
+          alpha: [1.2]
+          k_ranks: [4, 16]
+        query_args:
+          beam_width: [32, 64, 128, 256, 512, 1024, 1536]
+  - base_args: ['@metric', 'pq']
+    constructor: JasperDirectional
+    disabled: false
+    gpu: true
+    singularity_image: jasper
+    module: vibe.algorithms.jasper
+    name: jasper-directional-pq
+    run_groups:
+      jasper-pq-32:
+        args:
+          n_neighbors: [32]
+          alpha: [1.2]
+          k_ranks: [4, 16]
+        query_args:
+          beam_width: [16, 32, 64, 128, 256, 512, 1024, 1536]
+      jasper-pq-64:
+        args:
+          n_neighbors: [64]
+          alpha: [1.2]
+          k_ranks: [4, 16]
+        query_args:
+          beam_width: [32, 64, 128, 256, 512, 1024, 1536]
+  # ip/cosine/normalized all map to distance="ip" in module.py; Vamana-style robust
+  # pruning wants alpha near/at 1.0 for MIPS, unlike the >1.0 "long hop" alpha used for l2.
+  any:
+  - base_args: ['@metric']
+    constructor: Jasper
+    disabled: false
+    gpu: true
+    singularity_image: jasper
+    module: vibe.algorithms.jasper
+    name: jasper-base
+    run_groups:
+      jasper-8:
+        args:
+          n_neighbors: [8]
+          alpha: [0.95, 1.0]
+        query_args:
+          beam_width: [16, 32, 64, 128, 256, 512, 1024, 1536]
+      jasper-16:
+        args:
+          n_neighbors: [16]
+          alpha: [0.95, 1.0]
+        query_args:
+          beam_width: [16, 32, 64, 128, 256, 512, 1024, 1536]
+      jasper-32:
+        args:
+          n_neighbors: [32]
+          alpha: [0.95, 1.0]
+        query_args:
+          beam_width: [16, 32, 64, 128, 256, 512, 1024, 1536]
+      jasper-64:
+        args:
+          n_neighbors: [64]
+          alpha: [0.95, 1.0]
+        query_args:
+          beam_width: [32, 64, 128, 256, 512, 1024, 1536]
+  - base_args: ['@metric', 'cph']
+    constructor: JasperDirectional
+    disabled: false
+    gpu: true
+    singularity_image: jasper
+    module: vibe.algorithms.jasper
+    name: jasper-directional-cph
+    run_groups:
+      jasper-cph-32:
+        args:
+          n_neighbors: [32]
+          alpha: [0.95, 1.0]
+          k_ranks: [4, 16]
+        query_args:
+          beam_width: [16, 32, 64, 128, 256, 512, 1024, 1536]
+      jasper-cph-64:
+        args:
+          n_neighbors: [64]
+          alpha: [0.95, 1.0]
+          k_ranks: [4, 16]
+        query_args:
+          beam_width: [32, 64, 128, 256, 512, 1024, 1536]
+  - base_args: ['@metric', 'pq']
+    constructor: JasperDirectional
+    disabled: false
+    gpu: true
+    singularity_image: jasper
+    module: vibe.algorithms.jasper
+    name: jasper-directional-pq
+    run_groups:
+      jasper-pq-32:
+        args:
+          n_neighbors: [32]
+          alpha: [0.95, 1.0]
+          k_ranks: [4, 16]
+        query_args:
+          beam_width: [16, 32, 64, 128, 256, 512, 1024, 1536]
+      jasper-pq-64:
+        args:
+          n_neighbors: [64]
+          alpha: [0.95, 1.0]
+          k_ranks: [4, 16]
+        query_args:
+          beam_width: [32, 64, 128, 256, 512, 1024, 1536]

--- a/vibe/algorithms/jasper/image.def
+++ b/vibe/algorithms/jasper/image.def
@@ -1,0 +1,60 @@
+Bootstrap: localimage
+From: base.sif
+
+%post
+    mkdir -p /cache
+    export TMPDIR=/cache
+
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+
+    apt-get update
+    apt-get install -y libssl-dev
+
+    CUDA_VERSION="12.8.1"
+    CUDA_INSTALLER="cuda_12.8.1_570.124.06_linux.run"
+    wget https://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/local_installers/${CUDA_INSTALLER}
+
+    chmod +x ${CUDA_INSTALLER}
+    ./${CUDA_INSTALLER} --silent --toolkit --override
+    rm ${CUDA_INSTALLER}
+
+    export PATH=/usr/local/cuda/bin:${PATH}
+    export LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
+
+    # The CUDA runfile installer's --toolkit component does not reliably ship
+    # CCCL's pre-rendered CMake package configs (thrust-config.cmake etc.), so
+    # find_package(Thrust) fails even though the Thrust headers are present.
+    # Fetch CCCL directly, which checks in lib/cmake/{thrust,cub,libcudacxx}.
+    git clone --depth 1 --branch v2.8.5 https://github.com/NVIDIA/cccl.git /opt/cccl
+    export CMAKE_PREFIX_PATH=/opt/cccl:${CMAKE_PREFIX_PATH}
+
+    # Jasper.search() takes CUDA torch tensors, so we need a CUDA-enabled torch build
+    # (unlike e.g. ggnn, which only needs the CPU wheel).
+    pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cu128
+    pip install --no-cache-dir apache-tvm-ffi
+
+    git clone https://github.com/saltsystemslab/Jasper
+    cd Jasper
+    git config --global --add safe.directory '*'
+    git reset --hard 23647b9bad178a917e3628ff954c6aa749b9e5b9
+    # Submodules are registered with git@github.com: SSH URLs, which need an SSH
+    # key/agent that doesn't exist in this anonymous build container. Rewrite them
+    # to plain HTTPS so `git submodule update` can fetch without authentication.
+    git config --global "url.https://github.com/.insteadOf" "git@github.com:"
+    git submodule update --init --recursive
+
+    cmake -B build -DJASPER_BUILD_FFI=ON -DJASPER_BUILD_CMD=OFF -DCMAKE_PREFIX_PATH=/opt/cccl -DCMAKE_CUDA_ARCHITECTURES="90;120"
+    cmake --build build -j
+
+    # The build doesn't install libjasper_ffi.so into python/jasper/lib/, which is
+    # where tvm_ffi.load_module() looks for it at import time, so copy it manually.
+    mkdir -p python/jasper/lib
+    find build -name "libjasper_ffi.so" -exec cp {} python/jasper/lib/libjasper_ffi.so \;
+    test -f python/jasper/lib/libjasper_ffi.so || { echo "libjasper_ffi.so not found under build/"; exit 1; }
+
+    pip install -e python/
+
+%environment
+    export PATH=/usr/local/cuda/bin:${PATH}
+    export LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH}

--- a/vibe/algorithms/jasper/module.py
+++ b/vibe/algorithms/jasper/module.py
@@ -1,0 +1,99 @@
+import numpy as np
+import torch
+
+import jasper
+
+from ..base.module import BaseANN
+
+
+class Jasper(BaseANN):
+    def __init__(self, metric, n_neighbors, alpha):
+        self.metric = metric
+        self.distance = {"euclidean": "l2", "cosine": "ip", "ip": "ip", "normalized": "ip"}[metric]
+        self.n_neighbors = n_neighbors
+        self.alpha = alpha
+
+    def _to_device(self, X):
+        if X.dtype != np.float32:
+            X = X.astype(np.float32)
+        X = torch.tensor(X, device="cuda")
+        if self.metric == "cosine":
+            X = X / X.norm(dim=1, keepdim=True)
+        return X.to(torch.float16)
+
+    def fit(self, X):
+        self.num_points = len(X)
+        X_tensor = self._to_device(X)
+        self.graph = jasper.Graph.build(
+            X_tensor, n_neighbors=self.n_neighbors, distance=self.distance, alpha=self.alpha
+        )
+
+    def set_query_arguments(self, beam_width):
+        self.beam_width = beam_width
+
+    def batch_query(self, X, n):
+        X_tensor = self._to_device(X)
+        indices, _ = self.graph.search(X_tensor, k=n, beam_width=self.beam_width)
+        self.res = indices.detach().cpu().numpy()
+
+    def get_batch_results(self):
+        return [list(x[(x >= 0) & (x < self.num_points)]) for x in self.res]
+
+    def __str__(self):
+        return "Jasper(n_neighbors=%d, alpha=%g, beam_width=%d)" % (
+            self.n_neighbors,
+            self.alpha,
+            self.beam_width,
+        )
+
+
+class JasperDirectional(BaseANN):
+    def __init__(self, metric, search_type, n_neighbors, alpha, k_ranks):
+        self.metric = metric
+        self.distance = {"euclidean": "l2", "cosine": "ip", "ip": "ip", "normalized": "ip"}[metric]
+        self.search_type = search_type
+        self.n_neighbors = n_neighbors
+        self.alpha = alpha
+        self.k_ranks = k_ranks
+
+    def _to_device(self, X):
+        if X.dtype != np.float32:
+            X = X.astype(np.float32)
+        X = torch.tensor(X, device="cuda")
+        if self.metric == "cosine":
+            X = X / X.norm(dim=1, keepdim=True)
+        return X.to(torch.float16)
+
+    def fit(self, X):
+        self.num_points = len(X)
+        X_tensor = self._to_device(X)
+        build_kwargs = {"build_lsh": True} if self.search_type == "cph" else {"build_pq": True}
+        self.graph = jasper.Graph.build(
+            X_tensor,
+            n_neighbors=self.n_neighbors,
+            distance=self.distance,
+            alpha=self.alpha,
+            k_ranks=self.k_ranks,
+            **build_kwargs,
+        )
+
+    def set_query_arguments(self, beam_width):
+        self.beam_width = beam_width
+
+    def batch_query(self, X, n):
+        X_tensor = self._to_device(X)
+        search_fn = self.graph.directional_search if self.search_type == "cph" else self.graph.pq_search
+        indices, _ = search_fn(X_tensor, k=n, beam_width=self.beam_width)
+        self.res = indices.detach().cpu().numpy()
+
+    def get_batch_results(self):
+        return [list(x[(x >= 0) & (x < self.num_points)]) for x in self.res]
+
+    def __str__(self):
+        return "JasperDirectional(search_type=%s, n_neighbors=%d, alpha=%g, k_ranks=%d, beam_width=%d)" % (
+            self.search_type,
+            self.n_neighbors,
+            self.alpha,
+            self.k_ranks,
+            self.beam_width,
+        )


### PR DESCRIPTION
Integrates [Jasper](https://github.com/saltsystemslab/Jasper), a GPU-based graph ANN library. In total we added three groups of new method, all supports `l2`, `ip` and `cosine` distances:
1. `jasper-base`: Basic beam search on constructed graph index.
2. `jasper-directional-cph`: Directional beam search using cross-polytope hashing.
3. `jasper-directional-pq`: Directional beam search using product quantization.

Since we need compilation during image creation, we set the CUDA architecture to `sm90`, which should be the right version for `NVIDIA GH200` GPU. If it needs to be tested on other hardware, we need to change the corresponding cmake flag.

We tested on a machine with `NVIDIA RTX 6000 blackwell server edition` GPU on `agnews-mxbai-1024-euclidean` dataset against CAGRA.
<img width="3000" height="1800" alt="agnews-mxbai-1024-euclidean-qps-recall-gpu" src="https://github.com/user-attachments/assets/f8cb2902-c8de-406e-9360-99235f1d5dd7" />
