### PR TITLE
Record per-run search times and export QPS run-to-run spread

### DIFF
--- a/export_results.py
+++ b/export_results.py
@@ -56,6 +56,18 @@ def export_results(path, data_dir):
                     if "best_qps" in hfp[query_params].attrs
                     else 1 / hfp[query_params].attrs["best_search_time"]
                 )
+                # relative run-to-run spread of QPS across the repeated runs
+                # ((max - min) / max; 0.0 for a single run). Old result files
+                # without per-run values export null.
+                if "all_qps" in hfp[query_params].attrs:
+                    all_qps = np.asarray(hfp[query_params].attrs["all_qps"], dtype=float)
+                    qps_rel_spread = (
+                        float((all_qps.max() - all_qps.min()) / all_qps.max())
+                        if all_qps.size > 0 and all_qps.max() > 0
+                        else 0.0
+                    )
+                else:
+                    qps_rel_spread = None
                 build_time = hfp[query_params].attrs["build_time"]
                 index_size = hfp[query_params].attrs["index_size"]
                 summary = dict(
@@ -64,6 +76,7 @@ def export_results(path, data_dir):
                     algorithm=algo,
                     params=params,
                     qps=qps,
+                    qps_rel_spread=qps_rel_spread,
                     recall=recalls.mean(),
                     build_time=build_time,
                     index_size=index_size,

--- a/vibe/runner.py
+++ b/vibe/runner.py
@@ -32,6 +32,8 @@ def run_individual_query(
 
     best_search_time = float("inf")
     best_qps = 0.0
+    all_search_times = []
+    all_qps = []
     for i in range(run_count):
         print("Run %d/%d..." % (i + 1, run_count))
 
@@ -121,12 +123,19 @@ def run_individual_query(
         else:
             qps = len(X_test) / total
         best_qps = max(best_qps, qps)
+        all_search_times.append(search_time)
+        all_qps.append(qps)
 
     verbose = hasattr(algo, "query_verbose")
     attrs = {
         "gpu_mode": gpu,
         "best_search_time": best_search_time,
         "best_qps": best_qps,
+        # per-run values: the board reports the best of run_count attempts, so
+        # the run-to-run spread is what separates a real rank gap from timing
+        # noise on adjacent Pareto points
+        "all_search_times": all_search_times,
+        "all_qps": all_qps,
         "candidates": avg_candidates,
         "expect_extra": verbose,
         "name": str(algo),


### PR DESCRIPTION
## Why

`run_query` repeats each configuration `run_count` times and keeps only `best_search_time = min(...)` — the individual run times are discarded (runner.py). On the Pareto frontier, adjacent-rank QPS gaps are often smaller than run-to-run timing noise, and with only the best-of-N value stored, neither the exported data nor a reader can tell which gaps are real. Since every vendor benchmark war cites the neutral board, having the dispersion in the reference data helps the whole ecosystem — and it costs nothing to collect, the runs already happen.

## What

- `runner.py`: store `all_search_times` / `all_qps` attrs alongside the existing `best_*` values. Additive only — old result files remain readable, the selection logic is untouched.
- `export_results.py`: new summary column `qps_rel_spread` = (max − min)/max QPS across the runs; `null` for result files produced before this change, `0.0` for single-run configs.

Verified the h5py attrs round-trip for the list-valued attributes; both files compile clean. I deliberately did not touch the plotting pipeline in this PR — if you'd like spread whiskers (or a "gap < spread" annotation) on the Pareto plots, I'd be glad to follow up with that once the data field is in.

## Context

I work on benchmark-integrity tooling — recent public work includes an audit of 19 Kaggle competition leaderboards for rank stability and a label-leakage census of a popular ML benchmark. Your own reproducibility protocol work on ann-benchmarks (Information Systems 2019) is part of why this felt like the right board to offer it to: VIBE inheriting the ecosystem's reference role at birth is the moment to bake run-variance into the data model.